### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,31 +15,31 @@ Provides beyondcompare_package and beyondcompare_git_config resources for Beyond
 
 ### Windows
 
-- Beyond Compare is officially distributed by Scooter Software for Windows as downloadable installers rather than a native package repository.
-- Current Windows release on April 21, 2026: Beyond Compare `5.2.1.32035`.
-- Current supported Beyond Compare 4 release on April 21, 2026: Beyond Compare `4.4.7.28397`.
-- This cookbook defaults to Beyond Compare `4.4.7.28397` so the resource model stays compatible with the supported Beyond Compare 4 line while remaining upgradeable through resource properties.
+* Beyond Compare is officially distributed by Scooter Software for Windows as downloadable installers rather than a native package repository.
+* Current Windows release on April 21, 2026: Beyond Compare `5.2.1.32035`.
+* Current supported Beyond Compare 4 release on April 21, 2026: Beyond Compare `4.4.7.28397`.
+* This cookbook defaults to Beyond Compare `4.4.7.28397` so the resource model stays compatible with the supported Beyond Compare 4 line while remaining upgradeable through resource properties.
 
 ## Architecture Limitations
 
-- Scooter Software lists Beyond Compare 5 as supported on Windows 10 32-bit and 64-bit and on current Windows Server releases.
-- Windows 11 on ARM is supported through emulation, with a documented Explorer shell-extension limitation and possible performance impact.
-- Beyond Compare 4 provides alternate 32-bit and 64-bit MSI installers; Beyond Compare 5 removed MSI installers and relies on the EXE installer.
+* Scooter Software lists Beyond Compare 5 as supported on Windows 10 32-bit and 64-bit and on current Windows Server releases.
+* Windows 11 on ARM is supported through emulation, with a documented Explorer shell-extension limitation and possible performance impact.
+* Beyond Compare 4 provides alternate 32-bit and 64-bit MSI installers; Beyond Compare 5 removed MSI installers and relies on the EXE installer.
 
 ## Installer Constraints
 
-- The Windows installer uses Inno Setup.
-- Silent install options differ by major version:
-  - Beyond Compare 4: `/SP- /VERYSILENT /NORESTART`
-  - Beyond Compare 5: `/VERYSILENT /NORESTART /ALLUSERS /DISABLEUPDATES /SUPPRESSMSGBOXES`
-- The uninstaller also supports silent removal flags such as `/VERYSILENT /NORESTART`.
+* The Windows installer uses Inno Setup.
+* Silent install options differ by major version:
+  * Beyond Compare 4: `/SP- /VERYSILENT /NORESTART`
+  * Beyond Compare 5: `/VERYSILENT /NORESTART /ALLUSERS /DISABLEUPDATES /SUPPRESSMSGBOXES`
+* The uninstaller also supports silent removal flags such as `/VERYSILENT /NORESTART`.
 
 ## Supported Windows Platforms
 
-- Beyond Compare 5 is supported by Scooter Software on Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022, and Windows Server 2025.
-- Beyond Compare 4.4.7 remains supported on the same platforms and additionally on Windows Server 2012 and Windows Server 2012 R2.
+* Beyond Compare 5 is supported by Scooter Software on Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022, and Windows Server 2025.
+* Beyond Compare 4.4.7 remains supported on the same platforms and additionally on Windows Server 2012 and Windows Server 2012 R2.
 
 ## Known Issues
 
-- Git integration depends on Git for Windows already being installed. The `beyondcompare_git_config` resource safely no-ops when the configured `git_exe` path does not exist.
-- Scooter Software does not publish a Windows package repository or installer checksums on its download pages, so this cookbook exposes `source` and `checksum` as resource properties instead of hardcoding a rapidly stale checksum.
+* Git integration depends on Git for Windows already being installed. The `beyondcompare_git_config` resource safely no-ops when the configured `git_exe` path does not exist.
+* Scooter Software does not publish a Windows package repository or installer checksums on its download pages, so this cookbook exposes `source` and `checksum` as resource properties instead of hardcoding a rapidly stale checksum.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Provides beyondcompare_package and beyondcompare_git_config resources for Beyond Compare on Windows
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'beyondcompare'
+
+run_list 'test::default'
+
+cookbook 'beyondcompare', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ beyondcompare_git_config 'default'
 
 - The cookbook defaults to Beyond Compare `4.4.7.28397`, the latest supported Beyond Compare 4 release published by Scooter Software as of April 21, 2026.
 - Git integration is safe when Git for Windows is absent: `beyondcompare_git_config` does not run its `git config` commands unless `git.exe` exists.
-- Vendor support and installer limitations are documented in [LIMITATIONS.md](LIMITATIONS.md).
+- Vendor support and installer limitations are documented in [AGENTS.md](AGENTS.md).

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list